### PR TITLE
Add support for buffer keymaps

### DIFF
--- a/lua/mappy/init.lua
+++ b/lua/mappy/init.lua
@@ -78,8 +78,8 @@ function mappy:stable()
         if options.map.buffer then
             local bufnr = options.map.buffer == true and 0 or options.map.buffer
             options.map.buffer = nil
-            map = utils.gen_mapper(function(m, l, r, o)
-                vim.api.nvim_buf_set_keymap(bufnr, m, l, r, o)
+            map = utils.gen_mapper(function(...)
+                vim.api.nvim_buf_set_keymap(bufnr, ...)
             end, lhs, rhs, options.map)
         else
             map = utils.gen_mapper(vim.api.nvim_set_keymap, lhs, rhs, options.map)

--- a/lua/mappy/init.lua
+++ b/lua/mappy/init.lua
@@ -74,7 +74,16 @@ function mappy:stable()
             end
             return
         end
-        local map = utils.gen_mapper(vim.api.nvim_set_keymap, lhs, rhs, options.map)
+        local map
+        if options.map.buffer then
+            local bufnr = options.map.buffer == true and 0 or options.map.buffer
+            options.map.buffer = nil
+            map = utils.gen_mapper(function(m, l, r, o)
+                vim.api.nvim_buf_set_keymap(bufnr, m, l, r, o)
+            end, lhs, rhs, options.map)
+        else
+            map = utils.gen_mapper(vim.api.nvim_set_keymap, lhs, rhs, options.map)
+        end
         if type(options.mode) == "table" then
             for _, modechar in pairs(options.mode) do
                 map(modechar)


### PR DESCRIPTION
Hi 👋 

Thanks for the great project!

In the process of swapping over to this to wrap my keybinding function I found that it currently doesn't support keybindings bound to a buffer.

To implement I've pretty much just ripped off the neovim internal implementation.
https://github.com/neovim/neovim/blob/574a5822023939d534d922eaa345bb7e0633d2b8/runtime/lua/vim/keymap.lua#L82-L88

What do you think?